### PR TITLE
Scroll blocked in Root

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -63,7 +63,7 @@ body {
   font-family: "Poppins", sans-serif;
   min-height: 100vh;
   overflow-x: hidden;
-  overflow-y: auto;
+  overflow-y: clip;
   line-height: 1.5;
   font-size: 1.6rem;
   scrollbar-width: thin;

--- a/src/pages/landingPage/Home.tsx
+++ b/src/pages/landingPage/Home.tsx
@@ -12,7 +12,7 @@ import Extra from "../../components/landing/new/Extra";
 
 const Home: FC = () => {
   return (
-    <>
+    <div className="h-svh overflow-y-scroll">
       <Header />
       <div className="bg-primary/90">
         <Hero />
@@ -22,7 +22,7 @@ const Home: FC = () => {
       <div className="bg-[#121826] w-full pb-[40px]">
         <OurProduct />
         {/* <Testimonial /> */}
-{/*         <div className="bg-[#171D2D]">
+        {/*         <div className="bg-[#171D2D]">
           <FAQSection />
         </div> */}
         <CTASection />
@@ -32,7 +32,7 @@ const Home: FC = () => {
       </div>
 
       <Footer />
-    </>
+    </div>
   );
 };
 

--- a/src/pages/old_radio/radio/RadioHome.tsx
+++ b/src/pages/old_radio/radio/RadioHome.tsx
@@ -72,7 +72,7 @@ const RadioHome: React.FC = () => {
           {/* Play/Pause Button with Loading State */}
           <button
             onClick={handlePlayPause}
-            className={`absolute left-[50%] -translate-x-[50%] w-[48px] font-normal rounded-full text-white flex justify-center items-center gap-4`}
+            className={`absolute left-[50%] -translate-x-[50%] w-[84px] font-normal text-white flex justify-center items-center gap-4`}
             style={{ bottom: `${isPlaying ? 29 : 26}%` }}
             disabled={loading}
           >


### PR DESCRIPTION
- use "h-svh overflow-y-scroll" in scroll required pages root div element
- don't set overflow-y in root or body because we have some fixed layouts